### PR TITLE
ci(pages): update deployment actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,11 +82,11 @@ jobs:
 
       - name: Configure GitHub Pages
         if: github.event_name != 'pull_request'
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload GitHub Pages artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist
 
@@ -104,4 +104,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## What changed

Upgrade the GitHub Pages workflow to the current major releases:

- `actions/configure-pages@v6`
- `actions/upload-pages-artifact@v5`
- `actions/deploy-pages@v5`

## Why

The first successful production deployment completed with Node.js 20 deprecation annotations from the previous Pages action versions. These releases use the current Actions runtime and remove that maintenance warning.

## Validation

- verified the published release before this CI-only change
- confirmed the current release tags from the official action repositories
- `git diff --check HEAD`