### PR TITLE
feat(deploy): add Cloudflare Pages production setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+.wrangler
 yarn.lock
 
 # local env files

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Go the farthest place.
 
-[Preview](https://yunyoujun.github.io/go-far-away/)
+[在线体验](https://gfw.yyj.moe/) · [GitHub Pages 备用站](https://yunyoujun.github.io/go-far-away/)
 
 定位个人所在地，或通过输入经纬度的方式，计算出世界上距离自己最远的地方。（~~地球不完全是圆的这种细节，就不要在意啦！~~）
 
@@ -69,11 +69,21 @@ npm run verify:dist
 
 ## Deployment
 
-`master` 分支通过 GitHub Actions 发布到 GitHub Pages。首次启用时：
+主站通过 Cloudflare Pages 的 Git 集成发布，配置如下：
+
+- 生产分支：`master`
+- 构建命令：`npm run build:cloudflare`
+- 输出目录：`dist`
+- 自定义域名：`gfw.yyj.moe`
+
+Cloudflare Pages 的生产与预览环境均需配置 `VITE_AMAP_KEY` 和 `VITE_AMAP_SECURITY_CODE`。高德 Key 的域名白名单应同时包含 `gfw.yyj.moe` 与 `yunyoujun.github.io`。
+
+`master` 分支还会通过 GitHub Actions 发布到 GitHub Pages，作为备用站。首次启用时：
 
 1. 在仓库 `Settings → Pages` 中将 Source 设为 **GitHub Actions**。
 2. 在 `Settings → Secrets and variables → Actions` 中添加 `VITE_AMAP_KEY` 和 `VITE_AMAP_SECURITY_CODE`。
-3. 确保高德 Key 的域名白名单包含 `yunyoujun.github.io`。
+
+需要手动触发 Cloudflare Direct Upload 时，可以运行 `npm run deploy:cloudflare`；日常发布由 Git 集成自动完成。
 
 ## Intend
 

--- a/index.html
+++ b/index.html
@@ -8,13 +8,13 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="go-far-away 去远方">
     <meta property="og:description" content="定位所在地，计算地球上距离自己最远的地方。">
-    <meta property="og:url" content="https://yunyoujun.github.io/go-far-away/">
-    <meta property="og:image" content="https://yunyoujun.github.io/go-far-away/img/logo.png">
+    <meta property="og:url" content="%PUBLIC_URL%/">
+    <meta property="og:image" content="%PUBLIC_URL%/img/logo.png">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="go-far-away 去远方">
     <meta name="twitter:description" content="定位所在地，计算地球上距离自己最远的地方。">
-    <meta name="twitter:image" content="https://yunyoujun.github.io/go-far-away/img/logo.png">
-    <link rel="canonical" href="https://yunyoujun.github.io/go-far-away/">
+    <meta name="twitter:image" content="%PUBLIC_URL%/img/logo.png">
+    <link rel="canonical" href="%PUBLIC_URL%/">
     <link rel="manifest" href="%BASE_URL%manifest.webmanifest">
     <link rel="apple-touch-icon" href="%BASE_URL%img/icons/apple-touch-icon.png">
     <link rel="icon" href="%BASE_URL%favicon.ico">

--- a/package-lock.json
+++ b/package-lock.json
@@ -5686,9 +5686,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://www.yunyoujun.cn"
   },
   "license": "MIT",
-  "homepage": "https://yunyoujun.github.io/go-far-away/",
+  "homepage": "https://gfw.yyj.moe/",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },
@@ -17,6 +17,7 @@
     "dev": "vite",
     "serve": "vite",
     "build": "vite build",
+    "build:cloudflare": "VITE_BASE_PATH=/ VITE_PUBLIC_URL=https://gfw.yyj.moe vite build",
     "preview": "vite preview",
     "prepare": "simple-git-hooks",
     "lint": "eslint .",
@@ -24,7 +25,9 @@
     "test": "vitest",
     "test:unit": "vitest run",
     "typecheck": "vue-tsc --noEmit",
-    "verify:dist": "node scripts/verify-dist.mjs"
+    "verify:dist": "node scripts/verify-dist.mjs",
+    "verify:cloudflare": "VITE_BASE_PATH=/ VITE_PUBLIC_URL=https://gfw.yyj.moe npm run verify:dist",
+    "deploy:cloudflare": "npm run build:cloudflare && npm run verify:cloudflare && npx wrangler@4.120.0 pages deploy dist --project-name=go-far-away --branch=master"
   },
   "dependencies": {
     "@amap/amap-jsapi-loader": "^1.0.1",

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,11 @@
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: geolocation=(self)
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/sw.js
+  Cache-Control: no-cache

--- a/scripts/verify-dist.mjs
+++ b/scripts/verify-dist.mjs
@@ -4,6 +4,9 @@ import process from 'node:process'
 
 const distDirectory = new URL('../dist/', import.meta.url)
 const base = process.env.VITE_BASE_PATH || '/go-far-away/'
+const publicUrl = (process.env.VITE_PUBLIC_URL
+  || (base === '/' ? 'https://gfw.yyj.moe' : 'https://yunyoujun.github.io/go-far-away'))
+  .replace(/\/$/, '')
 const indexHtml = await readFile(new URL('index.html', distDirectory), 'utf8')
 
 function assert(condition, message) {
@@ -15,13 +18,21 @@ assert(
   indexHtml.includes('rel="manifest"'),
   'The production HTML must link to the generated web app manifest.',
 )
-assert(
-  !/["']\/assets\//.test(indexHtml),
-  'Production assets must not point at the domain root.',
-)
+if (base !== '/') {
+  assert(
+    !/["']\/assets\//.test(indexHtml),
+    'Subpath deployment assets must not point at the domain root.',
+  )
+}
 assert(
   indexHtml.includes(`${base}assets/`),
-  `Production assets must use the GitHub Pages base path ${base}.`,
+  `Production assets must use the configured base path ${base}.`,
+)
+assert(
+  indexHtml.includes(`rel="canonical" href="${publicUrl}/"`)
+  && indexHtml.includes(`property="og:url" content="${publicUrl}/"`)
+  && !indexHtml.includes('%PUBLIC_URL%'),
+  `Production metadata must use the configured public URL ${publicUrl}.`,
 )
 const manifest = JSON.parse(
   await readFile(new URL('manifest.webmanifest', distDirectory), 'utf8'),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,8 @@ import { defineConfig } from 'vite'
 import vuetify from 'vite-plugin-vuetify'
 
 const githubPagesBase = '/go-far-away/'
+const githubPagesUrl = 'https://yunyoujun.github.io/go-far-away'
+const cloudflarePagesUrl = 'https://gfw.yyj.moe'
 
 export default defineConfig(({ command }) => {
   const configuredBase = process.env.VITE_BASE_PATH
@@ -15,10 +17,19 @@ export default defineConfig(({ command }) => {
       ? configuredBase
       : githubPagesBase
     : '/'
+  const configuredPublicUrl = process.env.VITE_PUBLIC_URL
+  const publicUrl = (configuredPublicUrl != null && configuredPublicUrl.length > 0
+    ? configuredPublicUrl
+    : (base === '/' ? cloudflarePagesUrl : githubPagesUrl))
+    .replace(/\/$/, '')
 
   return {
     base,
     plugins: [
+      {
+        name: 'public-url-html',
+        transformIndexHtml: html => html.replaceAll('%PUBLIC_URL%', publicUrl),
+      },
       vue(),
       vuetify({ autoImport: true }),
     ],

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,5 @@
+{
+  "name": "go-far-away",
+  "pages_build_output_dir": "./dist",
+  "compatibility_date": "2026-08-08"
+}


### PR DESCRIPTION
## What changed

- add a Cloudflare Pages root-path build and Wrangler project configuration
- make canonical and social metadata follow the production domain
- add Cloudflare cache and security response headers
- keep the existing GitHub Pages subpath build as a backup
- update the deployment documentation for `gfw.yyj.moe`
- update `nanoid` in the lockfile to resolve the current high-severity advisory

## Why

The project needs a stable custom domain on Cloudflare Pages without breaking the existing GitHub Pages deployment.

## Validation

- `npm ci`
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit` (12 tests)
- `npm run build && npm run verify:dist`
- `npm run build:cloudflare && npm run verify:cloudflare`
- local `wrangler pages dev` smoke test
- `npm audit --audit-level=high` (0 vulnerabilities)