### PR TITLE
chore(deploy): use descriptive production domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Go the farthest place.
 
-[在线体验](https://gfw.yyj.moe/) · [GitHub Pages 备用站](https://yunyoujun.github.io/go-far-away/)
+[在线体验](https://go-far-away.yyj.moe/) · [GitHub Pages 备用站](https://yunyoujun.github.io/go-far-away/)
 
 定位个人所在地，或通过输入经纬度的方式，计算出世界上距离自己最远的地方。（~~地球不完全是圆的这种细节，就不要在意啦！~~）
 
@@ -74,9 +74,9 @@ npm run verify:dist
 - 生产分支：`master`
 - 构建命令：`npm run build:cloudflare`
 - 输出目录：`dist`
-- 自定义域名：`gfw.yyj.moe`
+- 自定义域名：`go-far-away.yyj.moe`
 
-Cloudflare Pages 的生产与预览环境均需配置 `VITE_AMAP_KEY` 和 `VITE_AMAP_SECURITY_CODE`。高德 Key 的域名白名单应同时包含 `gfw.yyj.moe` 与 `yunyoujun.github.io`。
+Cloudflare Pages 的生产与预览环境均需配置 `VITE_AMAP_KEY` 和 `VITE_AMAP_SECURITY_CODE`。高德 Key 的域名白名单应同时包含 `go-far-away.yyj.moe` 与 `yunyoujun.github.io`。
 
 `master` 分支还会通过 GitHub Actions 发布到 GitHub Pages，作为备用站。首次启用时：
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://www.yunyoujun.cn"
   },
   "license": "MIT",
-  "homepage": "https://gfw.yyj.moe/",
+  "homepage": "https://go-far-away.yyj.moe/",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },
@@ -17,7 +17,7 @@
     "dev": "vite",
     "serve": "vite",
     "build": "vite build",
-    "build:cloudflare": "VITE_BASE_PATH=/ VITE_PUBLIC_URL=https://gfw.yyj.moe vite build",
+    "build:cloudflare": "VITE_BASE_PATH=/ VITE_PUBLIC_URL=https://go-far-away.yyj.moe vite build",
     "preview": "vite preview",
     "prepare": "simple-git-hooks",
     "lint": "eslint .",
@@ -26,7 +26,7 @@
     "test:unit": "vitest run",
     "typecheck": "vue-tsc --noEmit",
     "verify:dist": "node scripts/verify-dist.mjs",
-    "verify:cloudflare": "VITE_BASE_PATH=/ VITE_PUBLIC_URL=https://gfw.yyj.moe npm run verify:dist",
+    "verify:cloudflare": "VITE_BASE_PATH=/ VITE_PUBLIC_URL=https://go-far-away.yyj.moe npm run verify:dist",
     "deploy:cloudflare": "npm run build:cloudflare && npm run verify:cloudflare && npx wrangler@4.120.0 pages deploy dist --project-name=go-far-away --branch=master"
   },
   "dependencies": {

--- a/scripts/verify-dist.mjs
+++ b/scripts/verify-dist.mjs
@@ -5,7 +5,7 @@ import process from 'node:process'
 const distDirectory = new URL('../dist/', import.meta.url)
 const base = process.env.VITE_BASE_PATH || '/go-far-away/'
 const publicUrl = (process.env.VITE_PUBLIC_URL
-  || (base === '/' ? 'https://gfw.yyj.moe' : 'https://yunyoujun.github.io/go-far-away'))
+  || (base === '/' ? 'https://go-far-away.yyj.moe' : 'https://yunyoujun.github.io/go-far-away'))
   .replace(/\/$/, '')
 const indexHtml = await readFile(new URL('index.html', distDirectory), 'utf8')
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ import vuetify from 'vite-plugin-vuetify'
 
 const githubPagesBase = '/go-far-away/'
 const githubPagesUrl = 'https://yunyoujun.github.io/go-far-away'
-const cloudflarePagesUrl = 'https://gfw.yyj.moe'
+const cloudflarePagesUrl = 'https://go-far-away.yyj.moe'
 
 export default defineConfig(({ command }) => {
   const configuredBase = process.env.VITE_BASE_PATH


### PR DESCRIPTION
## What changed

- switch the production URL from `gfw.yyj.moe` to `go-far-away.yyj.moe`
- update Cloudflare build metadata and verification defaults
- update the deployment documentation and AMap domain whitelist guidance

## Why

The descriptive hostname matches the project name and avoids the ambiguity of `gfw`.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:unit` (12 tests)
- `npm run build && npm run verify:dist`
- `npm run build:cloudflare && npm run verify:cloudflare`
- `npm audit --audit-level=high` (0 vulnerabilities)