### PR TITLE
chore(release): bump version to 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "go-far-away",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "go-far-away",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@amap/amap-jsapi-loader": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-far-away",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "description": "Go to the farthest place. Then you'll always be on your way home.",
   "author": {


### PR DESCRIPTION
## Summary

- bump the application version from `0.1.0` to `0.2.0`
- keep `package.json` and `package-lock.json` in sync
- reserve the historical `v0.1.0` tag for the legacy Express release

## Checks

- `npm run test:unit` — 16 tests passed
- `npm run typecheck`